### PR TITLE
chore: make docs AI-friendly with minimal metadata

### DIFF
--- a/01-Overview/1.what-is-nexio.mdx
+++ b/01-Overview/1.what-is-nexio.mdx
@@ -1,5 +1,6 @@
 ---
 title: "What is Nexio?"
+description: "Explains Nexio's BTC lending model connecting lenders with institutional borrowers through fixed terms, borrower-specific vaults, legal agreements, custody controls, and on-chain payment auditability."
 ---
 
 Nexio is a lending platform that connects BTC lenders with institutional borrowers through fixed-term, fixed-rate credit arrangements.

--- a/01-Overview/2.Key-Concepts.mdx
+++ b/01-Overview/2.Key-Concepts.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Key Concepts"
+description: "Defines Nexio's core concepts, including lenders, borrowers, borrower-specific vaults, fixed-rate BTC lending, legal agreements, custody, servicing, covenant oversight, and payment transparency."
 ---
 
 Nexio combines BTC-denominated lending with institutional legal, custody, and servicing workflows. The concepts below explain the core building blocks of the current model.

--- a/02-how-nexio-works/0.system-architecture.mdx
+++ b/02-how-nexio-works/0.system-architecture.mdx
@@ -1,5 +1,6 @@
 ---
 title: "System Architecture"
+description: "Describes Nexio's client, operations, and custody layers for lender onboarding, borrower vault selection, legal workflows, reporting, settlement, and repayment tracking."
 ---
 
 Nexio is organized as a three-layer BTC lending platform. These layers connect institutional lenders, borrower-specific credit facilities, and the custody and control processes that move BTC through the life of each loan.

--- a/02-how-nexio-works/1.borrower-overview.mdx
+++ b/02-how-nexio-works/1.borrower-overview.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Borrower Overview"
+description: "Explains how institutional borrowers use Nexio to access BTC liquidity through onboarding, facility terms, legal agreements, draws, interest payments, repayment, and covenant obligations."
 ---
 
 Nexio borrowers include institutional trading firms, market makers, arbitrage desks, and other professional counterparties seeking fixed-rate BTC-denominated credit for short- and medium-term strategies. These borrowers complete the KYC/KYB onboarding process with Nexio and already operate under regulatory oversight and manage large positions across established venues.

--- a/02-how-nexio-works/2.lender-overview.mdx
+++ b/02-how-nexio-works/2.lender-overview.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Lender Overview"
+description: "Explains how BTC lenders evaluate borrower-specific vaults, review borrower identity and facility terms, commit BTC, monitor payments, and receive fixed BTC-denominated income."
 ---
 
 Lending on Nexio is designed for institutions, funds, and BTC treasuries seeking predictable, fixed-rate yield while keeping Bitcoin in native custody. Lenders don’t create Series themselves; they allocate BTC into predefined Series that have published term sheets, fixed coupons, and borrowers that have already completed Nexio's onboarding process.

--- a/02-how-nexio-works/3.borrower-lender-faq.mdx
+++ b/02-how-nexio-works/3.borrower-lender-faq.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Nexio FAQ"
+description: "Answers borrower and lender questions about Nexio's BTC lending structure, vaults, facility terms, repayment obligations, custody, legal agreements, and risk controls."
 ---
 
 ### 1. What is Nexio in plain English?

--- a/03-strategies-and-yield-sources/1.strategy-overview.mdx
+++ b/03-strategies-and-yield-sources/1.strategy-overview.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Yield Strategies"
+description: "Introduces borrower strategy categories that may support facility repayment, including CME basis trades, delta-neutral funding strategies, and market-making activity."
 ---
 
 Every Nexio Series represents a single, borrower-specific yield strategy.

--- a/03-strategies-and-yield-sources/2.cme-basis.mdx
+++ b/03-strategies-and-yield-sources/2.cme-basis.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Strategy 1: CME-Basis"
+description: "Explains CME Bitcoin futures basis strategies, including spot and futures positioning, basis spread capture, facility repayment relevance, and key risks."
 ---
 
 Borrowers in this Series execute the **CME Basis trade**: a market-neutral strategy designed to capture the small but consistent price premium between spot Bitcoin and regulated Bitcoin futures on the [Chicago Mercantile Exchange (CME)](https://www.cmegroup.com/).

--- a/03-strategies-and-yield-sources/3.delta-neutral.mdx
+++ b/03-strategies-and-yield-sources/3.delta-neutral.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Strategy 2: Delta-Neutral Funding"
+description: "Explains delta-neutral funding strategies using spot and perpetual futures positions to earn funding spreads while managing market, exchange, liquidity, and operational risks."
 ---
 
 Borrowers in this Series execute the **Delta-Neutral Funding** strategy: a market-neutral approach that earns yield from the funding-rate differential between long and short perpetual futures across exchanges.

--- a/03-strategies-and-yield-sources/4.market-making.mdx
+++ b/03-strategies-and-yield-sources/4.market-making.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Strategy 3: Market Making"
+description: "Explains how market-making borrowers may earn spread income while managing inventory, liquidity, exchange, operational, and counterparty risks."
 ---
 
 Borrowers in this Series execute the Market-Making strategy: a trading approach that earns yield by providing BTC liquidity across exchanges and capturing the spread between buy and sell orders. Each Series is operated by a single verified borrower executing this market-making strategy under fixed terms and continuous on-chain monitoring.

--- a/04-risk-and-governance/1.Concentration-Limits.mdx
+++ b/04-risk-and-governance/1.Concentration-Limits.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Concentration Limits"
+description: "Describes how Nexio uses borrower, strategy, geography, tenor, and platform-level concentration limits to manage exposure across BTC lending facilities."
 ---
 
 **Concentration limits** are the guardrails Nexio enforces to prevent overexposure to any single borrower, strategy, or geography.

--- a/04-risk-and-governance/2.Covenant-Monitoring.mdx
+++ b/04-risk-and-governance/2.Covenant-Monitoring.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Covenant Monitoring"
+description: "Explains Nexio's covenant monitoring approach for borrower reporting, operational requirements, credit triggers, compliance obligations, escalation, and facility oversight."
 ---
 
 Covenants are borrower-specific financial and operational rules that govern how a facility can be used after it is approved and funded. They define the limits, reporting obligations, and escalation triggers Nexio uses to monitor borrower performance throughout the life of the loan.

--- a/04-risk-and-governance/3.Default-and-Workouts.mdx
+++ b/04-risk-and-governance/3.Default-and-Workouts.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Default and Workouts"
+description: "Explains how Nexio handles missed payments, covenant breaches, default events, workout planning, lender communication, enforcement rights, and recovery processes."
 ---
 
 Default in Nexio is a legal and servicing process, not just a price event.

--- a/05-Security-Custody-Compliance/1.Bitcoin-Custody.mdx
+++ b/05-Security-Custody-Compliance/1.Bitcoin-Custody.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Bitcoin Custody"
+description: "Describes Nexio's BTC custody approach, including segregated borrower vaults, trusted custody arrangements, controlled operations, settlement workflows, and payment auditability."
 ---
 
 Nexio uses centralized custody arrangements to hold and move BTC in support of its lending business. Nexio works with qualified custodians and controlled operational processes designed for institutional clients.

--- a/05-Security-Custody-Compliance/2.Compliance-Controls.mdx
+++ b/05-Security-Custody-Compliance/2.Compliance-Controls.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Compliance Controls"
+description: "Explains Nexio's compliance controls for borrower onboarding, institutional diligence, KYC, KYB, AML, sanctions screening, monitoring, and regulatory obligations."
 ---
 
 Because Nexio originates and services institutional BTC loans, compliance controls sit alongside onboarding, legal documentation, and custody operations. Their purpose is to ensure that only approved counterparties can access the platform and that BTC movements occur within defined legal and regulatory requirements.

--- a/05-Security-Custody-Compliance/3.Auditability-and-Legal.mdx
+++ b/05-Security-Custody-Compliance/3.Auditability-and-Legal.mdx
@@ -1,5 +1,6 @@
 ---
 title: "On-Chain Auditability & Legal Assurance"
+description: "Explains how Nexio combines legal agreements, custody records, servicing workflows, reporting, and on-chain payment visibility to support lender oversight and auditability."
 ---
 
 Nexio ensures that every BTC movement is verifiable directly on-chain. Instead of relying on PDF statements or delayed reporting, lenders, auditors, and counterparties can observe real-time data sourced from the same BTC transactions that govern vault operations.

--- a/06-community/community-links.mdx
+++ b/06-community/community-links.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Community Links"
+description: "Lists official Nexio community and public links, including the website, docs, X/Twitter, Discord, and support resources."
 ---
 
 Connect with our team and community to stay informed, collaborate, and build on top of Nexio’s Bitcoin credit infrastructure.

--- a/docs.json
+++ b/docs.json
@@ -117,28 +117,19 @@
   },
   "contextual": {
     "options": [
-      "assistant",
-      "grok",
-      "windsurf",
-      "chatgpt",
-      "vscode",
-      "mcp",
-      "aistudio",
       "copy",
-      "claude",
-      "devin-mcp",
-      "add-mcp",
-      "devin",
-      "perplexity",
       "view",
-      "cursor"
+      "chatgpt",
+      "claude",
+      "mcp",
+      "add-mcp",
+      "cursor",
+      "vscode"
     ],
     "display": "header"
   },
   "markdown": {
     "schema": true
   },
-  "seo": {
-    "indexing": "all"
-  }
+  "description": "Nexio Docs explain how Nexio connects BTC lenders with institutional borrowers through fixed-term, fixed-rate lending, borrower-specific vaults, legal agreements, custody controls, covenant monitoring, compliance workflows, and on-chain payment auditability."
 }


### PR DESCRIPTION
## Summary

- Adds a real docs-wide description for Mintlify-generated llms.txt
- Adds concise description frontmatter to the existing Nexio docs pages
- Removes seo.indexing: all so hidden Mintlify starter pages under /others do not leak into llms.txt, llms-full.txt, sitemap, or MCP search
- Tightens the Mintlify contextual AI menu to only the useful options: copy, view, ChatGPT, Claude, MCP, add-mcp, Cursor, and VS Code

## Not Included

- No custom llms.txt or llms-full.txt
- No skill.md
- No guessed API docs or product claims
- No new content pages

## Verification

- python3 -m json.tool docs.json
- validation script confirmed no /others references in docs.json
- validation script confirmed all 17 current Nexio docs pages have description frontmatter
- git diff --check